### PR TITLE
fix: preserve SNI hostname for proxy tunnels

### DIFF
--- a/httpcore/_async/http_proxy.py
+++ b/httpcore/_async/http_proxy.py
@@ -51,6 +51,12 @@ def merge_headers(
     return default_headers + override_headers
 
 
+def _authority_form_target(host: bytes, port: int) -> bytes:
+    if b":" in host and not host.startswith(b"["):
+        return b"[" + host + b"]:" + str(port).encode("ascii")
+    return host + b":" + str(port).encode("ascii")
+
+
 class AsyncHTTPProxy(AsyncConnectionPool):  # pragma: nocover
     """
     A connection pool that sends requests via an HTTP proxy.
@@ -268,7 +274,10 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
 
         async with self._connect_lock:
             if not self._connected:
-                target = b"%b:%d" % (self._remote_origin.host, self._remote_origin.port)
+                target = _authority_form_target(
+                    self._remote_origin.host,
+                    self._remote_origin.port,
+                )
 
                 connect_url = URL(
                     scheme=self._proxy_origin.scheme,
@@ -307,9 +316,11 @@ class AsyncTunnelHTTPConnection(AsyncConnectionInterface):
                 alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
+                sni_hostname = request.extensions.get("sni_hostname", None)
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": sni_hostname
+                    or self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
                 async with Trace("start_tls", logger, request, kwargs) as trace:

--- a/httpcore/_sync/http_proxy.py
+++ b/httpcore/_sync/http_proxy.py
@@ -51,6 +51,12 @@ def merge_headers(
     return default_headers + override_headers
 
 
+def _authority_form_target(host: bytes, port: int) -> bytes:
+    if b":" in host and not host.startswith(b"["):
+        return b"[" + host + b"]:" + str(port).encode("ascii")
+    return host + b":" + str(port).encode("ascii")
+
+
 class HTTPProxy(ConnectionPool):  # pragma: nocover
     """
     A connection pool that sends requests via an HTTP proxy.
@@ -268,7 +274,10 @@ class TunnelHTTPConnection(ConnectionInterface):
 
         with self._connect_lock:
             if not self._connected:
-                target = b"%b:%d" % (self._remote_origin.host, self._remote_origin.port)
+                target = _authority_form_target(
+                    self._remote_origin.host,
+                    self._remote_origin.port,
+                )
 
                 connect_url = URL(
                     scheme=self._proxy_origin.scheme,
@@ -307,9 +316,11 @@ class TunnelHTTPConnection(ConnectionInterface):
                 alpn_protocols = ["http/1.1", "h2"] if self._http2 else ["http/1.1"]
                 ssl_context.set_alpn_protocols(alpn_protocols)
 
+                sni_hostname = request.extensions.get("sni_hostname", None)
                 kwargs = {
                     "ssl_context": ssl_context,
-                    "server_hostname": self._remote_origin.host.decode("ascii"),
+                    "server_hostname": sni_hostname
+                    or self._remote_origin.host.decode("ascii"),
                     "timeout": timeout,
                 }
                 with Trace("start_tls", logger, request, kwargs) as trace:

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -126,10 +126,10 @@ async def test_proxy_tunneling():
 
 
 class CapturingProxyStream(AsyncMockStream):
-    def __init__(self, buffer: list[bytes]) -> None:
+    def __init__(self, buffer: typing.List[bytes]) -> None:
         super().__init__(buffer)
-        self.writes: list[bytes] = []
-        self.server_hostname: str | None = None
+        self.writes: typing.List[bytes] = []
+        self.server_hostname: typing.Optional[str] = None
 
     async def write(
         self, buffer: bytes, timeout: typing.Optional[float] = None

--- a/tests/_async/test_http_proxy.py
+++ b/tests/_async/test_http_proxy.py
@@ -125,6 +125,70 @@ async def test_proxy_tunneling():
         )
 
 
+class CapturingProxyStream(AsyncMockStream):
+    def __init__(self, buffer: list[bytes]) -> None:
+        super().__init__(buffer)
+        self.writes: list[bytes] = []
+        self.server_hostname: str | None = None
+
+    async def write(
+        self, buffer: bytes, timeout: typing.Optional[float] = None
+    ) -> None:
+        self.writes.append(buffer)
+
+    async def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: typing.Optional[str] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> AsyncNetworkStream:
+        self.server_hostname = server_hostname
+        return self
+
+
+class CapturingProxyBackend(AsyncMockBackend):
+    stream: CapturingProxyStream
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+    ) -> AsyncNetworkStream:
+        self.stream = CapturingProxyStream(list(self._buffer))
+        return self.stream
+
+
+@pytest.mark.anyio
+async def test_proxy_tunneling_uses_sni_hostname_extension():
+    network_backend = CapturingProxyBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    async with AsyncConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = await proxy.request(
+            "GET",
+            "https://[2001:db8::1]/",
+            extensions={"sni_hostname": "example.com"},
+        )
+
+    assert response.status == 200
+    assert network_backend.stream.server_hostname == "example.com"
+    assert network_backend.stream.writes[0].startswith(
+        b"CONNECT [2001:db8::1]:443 HTTP/1.1\r\n"
+    )
+
+
 # We need to adapt the mock backend here slightly in order to deal
 # with the proxy case. We do not want the initial connection to the proxy
 # to indicate an HTTP/2 connection, but we do want it to indicate HTTP/2
@@ -224,7 +288,7 @@ async def test_proxy_tunneling_with_403():
     """
     network_backend = AsyncMockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -126,12 +126,14 @@ def test_proxy_tunneling():
 
 
 class CapturingProxyStream(MockStream):
-    def __init__(self, buffer: list[bytes]) -> None:
+    def __init__(self, buffer: typing.List[bytes]) -> None:
         super().__init__(buffer)
-        self.writes: list[bytes] = []
-        self.server_hostname: str | None = None
+        self.writes: typing.List[bytes] = []
+        self.server_hostname: typing.Optional[str] = None
 
-    def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+    def write(
+        self, buffer: bytes, timeout: typing.Optional[float] = None
+    ) -> None:
         self.writes.append(buffer)
 
     def start_tls(
@@ -157,6 +159,7 @@ class CapturingProxyBackend(MockBackend):
     ) -> NetworkStream:
         self.stream = CapturingProxyStream(list(self._buffer))
         return self.stream
+
 
 
 def test_proxy_tunneling_uses_sni_hostname_extension():
@@ -285,7 +288,7 @@ def test_proxy_tunneling_with_403():
     """
     network_backend = MockBackend(
         [
-            b"HTTP/1.1 403 Permission Denied\r\n" b"\r\n",
+            b"HTTP/1.1 403 Permission Denied\r\n\r\n",
         ]
     )
 

--- a/tests/_sync/test_http_proxy.py
+++ b/tests/_sync/test_http_proxy.py
@@ -125,6 +125,67 @@ def test_proxy_tunneling():
         )
 
 
+class CapturingProxyStream(MockStream):
+    def __init__(self, buffer: list[bytes]) -> None:
+        super().__init__(buffer)
+        self.writes: list[bytes] = []
+        self.server_hostname: str | None = None
+
+    def write(self, buffer: bytes, timeout: typing.Optional[float] = None) -> None:
+        self.writes.append(buffer)
+
+    def start_tls(
+        self,
+        ssl_context: ssl.SSLContext,
+        server_hostname: typing.Optional[str] = None,
+        timeout: typing.Optional[float] = None,
+    ) -> NetworkStream:
+        self.server_hostname = server_hostname
+        return self
+
+
+class CapturingProxyBackend(MockBackend):
+    stream: CapturingProxyStream
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: typing.Optional[float] = None,
+        local_address: typing.Optional[str] = None,
+        socket_options: typing.Optional[typing.Iterable[SOCKET_OPTION]] = None,
+    ) -> NetworkStream:
+        self.stream = CapturingProxyStream(list(self._buffer))
+        return self.stream
+
+
+def test_proxy_tunneling_uses_sni_hostname_extension():
+    network_backend = CapturingProxyBackend(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            b"HTTP/1.1 200 OK\r\n",
+            b"Content-Length: 0\r\n",
+            b"\r\n",
+        ]
+    )
+
+    with ConnectionPool(
+        proxy=Proxy("http://localhost:8080/"),
+        network_backend=network_backend,
+    ) as proxy:
+        response = proxy.request(
+            "GET",
+            "https://[2001:db8::1]/",
+            extensions={"sni_hostname": "example.com"},
+        )
+
+    assert response.status == 200
+    assert network_backend.stream.server_hostname == "example.com"
+    assert network_backend.stream.writes[0].startswith(
+        b"CONNECT [2001:db8::1]:443 HTTP/1.1\r\n"
+    )
+
+
 # We need to adapt the mock backend here slightly in order to deal
 # with the proxy case. We do not want the initial connection to the proxy
 # to indicate an HTTP/2 connection, but we do want it to indicate HTTP/2


### PR DESCRIPTION
## Description

HTTP proxy CONNECT tunnels now honor the request `sni_hostname` extension when upgrading the tunneled stream to TLS. This matches the existing direct connection and SOCKS proxy behavior, and lets callers connect to one validated endpoint while preserving the original hostname for certificate validation.

CONNECT targets are also formatted with bracketed IPv6 authority syntax, so IPv6 literal tunnel targets are emitted as `[host]:port`.

## Self-Hosted Release Note

none

## Test Plan

- [x] Added sync and async HTTP proxy tunnel coverage for custom SNI plus IPv6 CONNECT target formatting.
- [x] `uv run --with pytest --with anyio --with trio --with h2 --with uvicorn python -m pytest tests/_sync/test_http_proxy.py tests/_async/test_http_proxy.py -q`
- [x] `uv run --with ruff ruff check httpcore/_async/http_proxy.py tests/_async/test_http_proxy.py`
- [x] `uv run --with ruff ruff format --check httpcore/_async/http_proxy.py tests/_async/test_http_proxy.py`
